### PR TITLE
Fixes for iris hmac auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ var ic =require('./app.js');
 config = {
   app   :  "test-app",
   key   :  "sdffdssdf",
-  url  :  "http://127.0.0.1:16649/v0"
+  url  :  "http://127.0.0.1:16649/"
 }
 
 IrisClient = new ic(config);

--- a/app.js
+++ b/app.js
@@ -53,16 +53,19 @@ IrisClient.prototype.notify = function(role, target, subject, priority, mode, bo
 }
 //attaches the headers and sends the request to each call.
 IrisClient.prototype.sendReq= function(path, body){
-  var words =`${(new Date).getTime()/5} POST ${path} ${body}`;
-  var headers= {'AUTHORIZATION': `hmac ${self.config.app}:${crypto.createHmac('sha512', self.config.key).update(words).digest('base64')}`};
+  var path = `${VERSION_PREFIX}/${path}`;
+  var body = JSON.stringify(body);
+  var words =`${Math.floor(Math.round((new Date()).getTime() / 1000) / 5) - 1} POST ${path} ${body}`;
+  var hmac = `hmac ${self.config.app}:${crypto.createHmac('sha512', self.config.key).update(words).digest('base64').replace(/\+/g, '-').replace(/\//g, '_')}`;
+  var headers = {'AUTHORIZATION': hmac};
 
   r = request.post(
     {
-            uri      :`${self.config.url}${VERSION_PREFIX}/${path}`,
+            uri      :`${self.config.url}${path}`,
             headers  : headers,
-            body     : JSON.stringify(body)
+            body     : body
     },function (error, response, body) {
-      if (error || response.status>201) {
+      if (error || response.statusCode>201) {
         throw new exceptions.BadResponse('Server returned an error: '+ error);
       }
       console.log(body);


### PR DESCRIPTION
Currently, this library works when iris has its auth disabled, but it falls
short when auth is enabled.

Tested on mac and rhel6.

Tweaks needed:

- Make the date window divided by 1000 (to go from miliseconds to seconds) and
  floor'd to not be a decimal after the division.

- Make the base64'd digest match the slightly url-encoded version that python
  uses, with + and / encoded differently.

- The path part of the digest needs the /v0 prefix

- The body part of the digest needs to be the json string